### PR TITLE
Install postgresql-server and postgresql-contrib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
     libxslt-devel \
     postgresql \
     postgresql-devel \
+    postgresql-server \
+    postgresql-contrib \
     libpq-devel \
     wget \
     dnf-plugins-core


### PR DESCRIPTION
postgresql-server is required by the tests as it provides
the pg_ctl binary needed by pytest-postgresql.

postgresql-contrib provides the pg_trgm extension that is
required by passari-workflow and passari-web-ui.