### PR TITLE
Ignore keys directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# The "keys" directory (for METS and SFTP key files)
+/keys


### PR DESCRIPTION
To specify key files for METS signing or SFTP connection they have to be placed on some path that is available on the container.  This can now be done by creating a directory named keys/ and placing them there.  That directory will be available on the container as /app/keys, since docker-compose mounts the workdir to /app as a volume.