### PR TITLE
Dockerfile: Remove PostgreSQL server from the app image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
     libxslt-devel \
     postgresql \
     postgresql-devel \
-    postgresql-server \
-    postgresql-contrib \
     libpq-devel \
     wget \
     dnf-plugins-core


### PR DESCRIPTION
The postgresql-server and postgresql-contrib packages were needed previously, because the pytest setup was starting its own PostgreSQL server.  Now it has been changed so that it connects to already running PostgreSQL server and therefore it can utilize a PG instance running on another container.  Therefore remove the now unneeded packages from the image.