### PR TITLE
Data directory for objects and archive

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -36,12 +36,12 @@ PASSARI_MUSEUMPLUS_PASSWORD=
 #PASSARI_WORKFLOW_DB_URL=postgresql://passari:passari@db/passari
 #PASSARI_WORKFLOW_REDIS_URL=redis://redis:6379/0
 
-PASSARI_WORKFLOW_PACKAGE_DIR=
-PASSARI_WORKFLOW_ARCHIVE_DIR=
+PASSARI_WORKFLOW_PACKAGE_DIR=/data/objects
+PASSARI_WORKFLOW_ARCHIVE_DIR=/data/archive
 
 # Variables for configs/passari-web-ui.toml ===============================
 
 PASSARI_WEB_UI_SECRET_KEY=test secret key DO NOT USE
-PASSARI_WEB_UI_SECURITY_PASSWORD_SALT='replace with random string'
-PASSARI_WEB_UI_CUSTOM_LOG_LEVELS='passlib:INFO'
+PASSARI_WEB_UI_SECURITY_PASSWORD_SALT=replace with random string
+PASSARI_WEB_UI_CUSTOM_LOG_LEVELS=passlib:INFO
 PASSARI_WEB_UI_MUSEUMPLUS_UI_URL=https://mpfinlandfhatest.zetcom.app/v#!m

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,9 +125,16 @@ RUN cd /etc && \
 
 COPY docker-entrypoint.sh .
 
-USER appuser
+# Data directory for museum object workspace and archived objects
+RUN \
+    mkdir -p /data/objects /data/archive && \
+    chown -R appuser:appuser /data && \
+    ln -s /data/objects /home/appuser/MuseumObjects && \
+    ln -s /data/archive /home/appuser/MuseumObjectArchive && \
+    chown -h appuser:appuser /home/appuser/MuseumObjects && \
+    chown -h appuser:appuser /home/appuser/MuseumObjectArchive
 
-# Create workspace directory for Passari data files
-RUN mkdir /home/appuser/MuseumObjects
+# Run as appuser by default
+USER appuser
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         condition: service_healthy
     volumes:
       - .:/app
+      - passari_data:/data
     ports:
       - "127.0.0.1:5000:5000"
     environment:
@@ -48,5 +49,6 @@ services:
       - "127.0.0.1:8081:8081"
 
 volumes:
+  passari_data:
   postgres_data:
   redis_data:


### PR DESCRIPTION
Create a data directory for the Passari object storage and archive and make it a volume in the docker-compose setup.

Set the correct PASSARI_WORKFLOW_PACKAGE_DIR and
PASSARI_WORKFLOW_ARCHIVE_DIR variables so that passari-workflow is configured with the correct paths.

Additionally create symbolic links MuseumObjects and MuseumObjectArchive to the home directory, because passari's CLI tools use those as default values.