### PR TITLE
configs/passari.toml: Set object_preservation_field_name

### DIFF
--- a/configs/passari.toml
+++ b/configs/passari.toml
@@ -33,7 +33,7 @@ lido_report_id='$PASSARI_MUSEUMPLUS_LIDO_REPORT_ID'
 
 # Field used for storing the preservation history for an object
 # Needs to have the 'Clob' data type
-object_preservation_field_name=''
+object_preservation_field_name='ObjPASLog01Clb'
 object_preservation_field_type='dataField'
 
 # Whether to update MuseumPlus log field with preservation events


### PR DESCRIPTION
Set the object_preservation_field_name to ObjPASLog01Clb.  This was visible in the module definition (which can be requested via the API with `GET .../ria-ws/application/module/Object/definition` request):

    <?xml version="1.0" encoding="UTF-8"?>
    <application xmlns="http://www.zetcom.com/ria/ws/module">
      <modules>
        <module name="Object">
          <moduleItem>
            <systemField dataType="Long" name="__id"/>
            ...
            <dataField dataType="Clob" name="ObjPASLog01Clb"/>
            ...
          </moduleItem>
        </module>
      </modules>
    </application>

That Object definition response also reveals that the "dataField" is the correct field type.